### PR TITLE
Remove Roblox ProcessService check that disables colors

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -116,15 +116,8 @@ local function compositeStyler(style, otherStyle)
 	return createStyler(style.open .. otherStyle.open, otherStyle.close .. style.close)
 end
 
-local function foundProcessService()
-	local success = pcall(function()
-		game:GetService("ProcessService")
-	end)
-	return success
-end
-
 local Chalk = { level = 2 }
-if _G.NOCOLOR or not foundProcessService() then
+if _G.NOCOLOR then
 	Chalk.level = 0
 end
 


### PR DESCRIPTION
The coloring can still be disabled using the `NOCOLOR` global variable.

This is useful for supporting any Lua platforms, I think it was the only Roblox specific bit of the library.